### PR TITLE
Add linting to CI

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -1,0 +1,35 @@
+name: Super Linter
+
+# Controls when the workflow will run
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        # Slim version does not support rust linters, dotenv linters, armttk linters, pwsh linters and c# linters
+        uses: github/super-linter/slim@v4.8.1
+        env:
+          # When set to false, only new or edited files will be parsed for validation.
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          # Mark the status of each individual linter run in the Checks section of a pull request
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_PYTHON_PYLINT: false


### PR DESCRIPTION
The workflow will trigger on PRs targeting `main` and on pushes
that are not pushes on `main`.

Using the `slim` version to gain some speed compared to the full
version of super-linter.

Validation only runs on files that are changed and not the entire
codebase.

We will probably need to configure the different linters, but that
can be part of a separate commit.

See: #19