### PR TITLE
Bump super-linter from 4.8.1 to 4.*

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Lint Code Base
         # Slim version does not support rust linters, dotenv linters, armttk linters, pwsh linters and c# linters
-        uses: github/super-linter/slim@v4.8.1
+        uses: github/super-linter/slim@v4
         env:
           # When set to false, only new or edited files will be parsed for validation.
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
I believe there were some fixes introduced in 4.8.4 for mypy.

Ideally I would prefer to fix the minor version, but super-linter
does not publish tags for it. Only patch and major tags.

Instead of fixing and manually upping the version I think it's ok
to pin to the major version in this case.

See: #19