### PR TITLE
Update super-linter configuration

### DIFF
--- a/.github/linters/.isort.cfg
+++ b/.github/linters/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile=black
+; needed because super-linter is not aware
+known_first_party=app

--- a/.github/linters/.mypy.ini
+++ b/.github/linters/.mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
+; needed because super-linter is not aware of the python imports
+ignore_missing_imports = True
+
 warn_unused_configs = True
 disallow_any_generics = True
 disallow_subclassing_any = True
@@ -6,7 +9,8 @@ disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 check_untyped_defs = True
-disallow_untyped_decorators = True
+; cannot enable because of the type decorators used from fastapi
+; disallow_untyped_decorators = True
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -2,8 +2,6 @@ name: Super Linter
 
 # Controls when the workflow will run
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     branches: [main]
 
@@ -12,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Lint Code Base
+    name: Lint Code
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +21,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Lint Code Base
+      - name: Lint Code
         # Slim version does not support rust linters, dotenv linters, armttk linters, pwsh linters and c# linters
         uses: github/super-linter/slim@v4.8.1
         env:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,9 @@ isort = "^5.10.1"
 mypy = "^0.910"
 pytest = "^6.2.5"
 
+[tool.isort]
+profile = "black"
+
 [tool.mypy]
 warn_unused_configs = true
 disallow_any_generics = true


### PR DESCRIPTION
Configure isort to play nice with black. It also needs help in telling
the difference between 1st and 3rd party packages within super-linter.

Configure mypy to ignore missing imports as super-linter is not aware
of the project's dependencies. Checking for untyped decorators also
have to be disabled because of the decorators we use from fastapi.

We don't actually need to run the linter on pushes. (PR is enough.)

Close: #19