### PR TITLE
Add /health route to the app

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,3 +4,13 @@
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat)](https://pycqa.github.io/isort/)
 
 ---
+## Project structure
+```console
+.
+├── app  # src for the application
+│   ├── config.py  # reading in settings from env
+│   ├── main.py  # main entrypoint for the application
+│   ├── routers  # route definitions
+│   └── schemas  # pydantic model definitions
+└── tests  # tests
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,13 @@
 import fastapi
 
 from app import config
+from app.routers import health
 
 settings = config.get_settings()
 app = fastapi.FastAPI(title="alphafold-on-fire", version=settings.releaseId)
+
+
+app.include_router(health.router, prefix="/health", tags=["health"])
 
 
 @app.get("/")

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,29 @@
+import fastapi
+from fastapi import responses
+
+from app import config, schemas
+
+router = fastapi.APIRouter()
+
+
+class HealthResponse(responses.JSONResponse):
+    media_type = "application/health+json"
+
+
+@router.get(
+    "",
+    response_class=HealthResponse,
+    response_model=schemas.Health,
+)
+async def get_health(
+    response: HealthResponse,
+    settings: config.Settings = fastapi.Depends(config.get_settings),
+) -> schemas.Health:
+    response.headers["Cache-Control"] = "max-age=3600"
+
+    content = {
+        "status": schemas.Status.PASS,
+        "version": settings.version,
+        "releaseId": settings.releaseId,
+    }
+    return schemas.Health(**content)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+from app.schemas.health import Health, Status
+
+__all__ = ["Health", "Status"]

--- a/backend/app/schemas/health.py
+++ b/backend/app/schemas/health.py
@@ -1,0 +1,15 @@
+import enum
+
+import pydantic
+
+
+class Status(str, enum.Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    WARN = "warn"
+
+
+class Health(pydantic.BaseModel):
+    status: Status
+    version: str
+    releaseId: str

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -1,0 +1,30 @@
+import operator
+
+import pytest
+from fastapi import testclient
+
+from app import config, main
+
+client = testclient.TestClient(main.app)
+settings = config.get_settings()
+
+
+def test_get_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/health+json"
+    assert response.headers["cache-control"] == "max-age=3600"
+    payload = response.json()
+    for key in ["status", "version", "releaseId"]:
+        assert key in payload
+    assert payload["status"] == "pass"
+    assert payload["version"] == settings.version
+    assert payload["releaseId"] == settings.releaseId
+
+
+@pytest.mark.parametrize(
+    "method", ["head", "post", "put", "delete", "options", "patch"]
+)
+def test_health(method: str) -> None:
+    response = operator.methodcaller(method, "/health")(client)
+    assert response.status_code == 405


### PR DESCRIPTION
A route according to the draft specs. Decided not code the full
schema spec for class Health, because most fields are optional.
Only coded the part we are actually returning. We can extend on this
when we add more to the application. (e.g. db connection check)

Close: #6