### PR TITLE
Allow subclassing any in super-linter

### DIFF
--- a/.github/linters/.mypy.ini
+++ b/.github/linters/.mypy.ini
@@ -4,7 +4,8 @@ ignore_missing_imports = True
 
 warn_unused_configs = True
 disallow_any_generics = True
-disallow_subclassing_any = True
+; cannot enable because of subclassing from pydantic and fastapi
+; disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True


### PR DESCRIPTION
Have to allow because super-linter cannot follow the imports.