### PR TITLE
Use containers in test jobs

### DIFF
--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Test Code
     runs-on: ubuntu-latest
+    container: python:3.9
     defaults:
       run:
         # Step into backend
@@ -28,11 +29,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9.*"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Instead of setting up python on the base image, let's use a container.
This will work better with side services such as databases that are
created for the pipeline.