### PR TITLE
Fix yamllint reported errors

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -1,3 +1,4 @@
+---
 version: "3.8"
 
 services:
@@ -12,7 +13,7 @@ services:
     volumes:
       - aof-postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -d aof -U admin" ]
+      test: ["CMD-SHELL", "pg_isready -d aof -U admin"]
 
   keycloak:
     container_name: keycloak-aof


### PR DESCRIPTION
It looks like github-super linter might not have worked correctly
before, but it received a patch update.