### PR TITLE
Update alembic version generation config

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -57,12 +57,15 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # post_write_hooks defines scripts or Python functions that are run
 # on newly generated revision scripts.  See the documentation for further
 # detail and examples
+hooks = black,isort
 
-# format using "black" - use the console_scripts runner, against the "black" entrypoint
-# hooks = black
-# black.type = console_scripts
-# black.entrypoint = black
-# black.options = -l 79 REVISION_SCRIPT_FILENAME
+black.type = console_scripts
+black.entrypoint = black
+
+isort.type = console_scripts
+isort.entrypoint = isort
+isort.options = -o alembic  # force to recognize alembic as 3rd party
+
 
 # Logging configuration
 [loggers]

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -16,9 +16,9 @@ branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
 
-def upgrade():
+def upgrade() -> None:
     ${upgrades if upgrades else "pass"}
 
 
-def downgrade():
+def downgrade() -> None:
     ${downgrades if downgrades else "pass"}


### PR DESCRIPTION
Use `black` and `isort` to auto-format generated python scripts.
For some reason `alembic` is always recognized as first party, which
it isn't.. hence forcing it to be 3rd party.

Adding `-> None:` type hint for mypy compatibility.