### PR TITLE
Update keycloak config

### DIFF
--- a/backend/keycloak/dev-realm.json
+++ b/backend/keycloak/dev-realm.json
@@ -68,6 +68,7 @@
       "composites" : {
         "realm" : [ "offline_access", "uma_authorization" ],
         "client" : {
+          "alphafold-backend" : [ "authenticated" ],
           "account" : [ "view-profile", "manage-account" ]
         }
       },
@@ -76,7 +77,6 @@
       "attributes" : { }
     } ],
     "client" : {
-      "alphafold-on-fire" : [ ],
       "realm-management" : [ {
         "id" : "b47b0068-7052-4af0-baff-cadf6e64e94a",
         "name" : "query-clients",
@@ -246,7 +246,16 @@
         "attributes" : { }
       } ],
       "security-admin-console" : [ ],
+      "alphafold-frontend" : [ ],
       "admin-cli" : [ ],
+      "alphafold-backend" : [ {
+        "id" : "fc3bc7d1-7a99-4aba-9ddb-205a5d0809c5",
+        "name" : "authenticated",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5362d163-0c24-403b-b041-8814feebd8b8",
+        "attributes" : { }
+      } ],
       "account-console" : [ ],
       "broker" : [ {
         "id" : "8a728df1-4f37-4aa1-bfec-d07f9ce87ba4",
@@ -489,8 +498,58 @@
     "defaultClientScopes" : [ "web-origins", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
+    "id" : "5362d163-0c24-403b-b041-8814feebd8b8",
+    "clientId" : "alphafold-backend",
+    "rootUrl" : "http://localhost:8000",
+    "adminUrl" : "http://localhost:8000",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:8000/*" ],
+    "webOrigins" : [ "http://localhost:8000" ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "saml.artifact.binding" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml_force_name_id_format" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
     "id" : "df446bfc-e395-40ec-8d40-dc6522f6e353",
-    "clientId" : "alphafold-on-fire",
+    "clientId" : "alphafold-frontend",
     "name" : "",
     "rootUrl" : "http://localhost:8000",
     "adminUrl" : "http://localhost:8000",
@@ -1122,7 +1181,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper" ]
       }
     }, {
       "id" : "6ff116aa-6749-4bd7-b09a-dc8ef7f933c3",
@@ -1150,7 +1209,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper" ]
       }
     }, {
       "id" : "a9b70be3-a6d8-4aa4-9ed5-4801b5d9497e",
@@ -1218,7 +1277,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "e7846968-334a-468d-a6fe-d2a1d7a8dd79",
+    "id" : "abace3f2-f584-42d6-ac13-db076ed89c7b",
     "alias" : "Account verification options",
     "description" : "Method with which to verity the existing account",
     "providerId" : "basic-flow",
@@ -1240,7 +1299,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "c6f450e3-3893-457a-928e-4aeae49e10a4",
+    "id" : "5e5bedea-15e2-4933-89dd-30809dcbe69e",
     "alias" : "Authentication Options",
     "description" : "Authentication options.",
     "providerId" : "basic-flow",
@@ -1269,7 +1328,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "1c9da2af-6bb1-42f2-a774-ee28553205be",
+    "id" : "44bbbe9d-37af-4ecf-ab24-48f25b928a0e",
     "alias" : "Browser - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1291,7 +1350,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "83f142b2-5fac-4325-aa34-43118c7c2f1d",
+    "id" : "b4c4ea92-a4f7-4e16-bd5b-2e776dc38d49",
     "alias" : "Direct Grant - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1313,7 +1372,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "3cf49a46-2b3c-44f9-8cc4-88e7a7914826",
+    "id" : "384fe872-bb89-4bdf-84a7-c962251974db",
     "alias" : "First broker login - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1335,7 +1394,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "a5770122-04ea-4a5c-936b-aa5c1e7ed83b",
+    "id" : "89c246bf-374b-4fe5-98ef-73aa3a273063",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1357,7 +1416,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "0be3ab51-2425-4bc7-9fd5-e2de8e4cae49",
+    "id" : "1617885f-783e-4523-b91c-80a056f97ace",
     "alias" : "Reset - Conditional OTP",
     "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
     "providerId" : "basic-flow",
@@ -1379,7 +1438,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "e8a26155-b893-476f-8292-5637427b6bb8",
+    "id" : "e1ecca4b-6917-4986-b1ee-2f689f5268ee",
     "alias" : "User creation or linking",
     "description" : "Flow for the existing/non-existing user alternatives",
     "providerId" : "basic-flow",
@@ -1402,7 +1461,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "d14cfea6-5e3d-4bad-b3b5-a5fa9fe8e210",
+    "id" : "0df2d6ab-7c3e-4d04-be6c-a0d80090b67c",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1424,7 +1483,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "0599f92b-7185-4c7d-96fb-9a1fd9085800",
+    "id" : "8319e2e8-5ce1-41dc-a91c-177061525072",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1460,7 +1519,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "94780d55-5111-4860-9f0b-b5ce44087d49",
+    "id" : "1b08065a-3ddc-411a-ae91-d2ebaa49022b",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1496,7 +1555,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "8a1de4b2-3a94-4e8f-ad3a-ee80d2715140",
+    "id" : "ca318321-dbae-49a7-823f-6dd4ea5ad47a",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1525,7 +1584,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "09240277-0a8b-4238-8a1c-8f3f94e77909",
+    "id" : "80eac3b1-a61e-495c-9af1-0574836b5c1b",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1540,7 +1599,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "cb930ac0-4f8c-472e-878a-4bbe815df29d",
+    "id" : "e706d04b-e018-4a13-9557-8ea353493481",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1563,7 +1622,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "c3606787-3fbe-4149-b9dd-f30fe7599edc",
+    "id" : "1d26fd94-4273-4a12-9074-38ac0fe2168e",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1585,7 +1644,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "7a5ef278-f13d-40cb-9183-8125b8cc5ee9",
+    "id" : "8fd46f63-24c4-427f-9352-5d660070e5d4",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1607,7 +1666,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "b83282d7-1017-4f61-81a3-6e41bc9daafd",
+    "id" : "c4fc0ba2-de62-418e-a592-373c22fed44e",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1623,7 +1682,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "fb5ccbed-894b-4538-b28d-88f5114d5e6c",
+    "id" : "41ef5b57-ba36-4fc6-8f0c-bfc098a7b8ba",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1659,7 +1718,7 @@
       "autheticatorFlow" : false
     } ]
   }, {
-    "id" : "50436a7f-ce55-45f7-8f77-8e77cb951441",
+    "id" : "27dc0e0b-596b-49d9-9fc5-f79d9ce623e2",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1695,7 +1754,7 @@
       "autheticatorFlow" : true
     } ]
   }, {
-    "id" : "41d46c6c-7509-453c-a9fc-163011fdd093",
+    "id" : "faaab544-b53e-4c2e-a8bb-ccc56093b69d",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1711,13 +1770,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "6eed34f3-0ca3-4013-8ccb-dca3e80033d9",
+    "id" : "7baa0284-1eea-4c32-8935-fd789d83b140",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "eb3c09c1-d824-40f2-8d34-c75c0c7394c6",
+    "id" : "fd5ac635-8eea-4836-a346-d2282ae0c0e5",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"


### PR DESCRIPTION
Rename `alphafold-on-fire` to `alphafold-frontend`
Add new client `alphafold-backend`, type `bearer-only`
Add role `authenticated` to alphafold-backend
Make the role an automatic default role for every user in keycloak
(Under roles -> default roles -> client roles -> alphafold-backend)

When a new auth request comes in for any client - if the client returns
a token with full scopes - the access token will contain the new role
for the user and `aud` will be populated with `alphafold-backend`.
The value of `aud` becomes a list.
e.g. `["alphafold-backend","account"]`