### PR TITLE
Change lint pipeline to use installed packages

### DIFF
--- a/.github/workflows/lint-backend.yaml
+++ b/.github/workflows/lint-backend.yaml
@@ -27,13 +27,21 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      
-      - name: Ruff
-        uses: chartboost/ruff-action@v1
+
+      - name: Install poetry
+        run: pipx install poetry==1.4.2
+
+      - name: Set up python
+        uses: actions/setup-python@v4
         with:
-          version: 0.0.265
+          python-version: '3.10'
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi
+
+      - name: Ruff
+        run: poetry run ruff check .
 
       - name: Black
-        uses: psf/black@stable
-        with:
-          version: "23.3.0"
+        run: poetry run black . --check --diff


### PR DESCRIPTION
There won't be a need to change package versions in separate places. This also ensures that the correct lint package versions are used in the pipeline.